### PR TITLE
Add the missing Detail() function

### DIFF
--- a/station.go
+++ b/station.go
@@ -7,6 +7,7 @@ import (
 
 // StationService is an interface to query station information from the Tankerkönig-API.
 type StationService interface {
+	Detail(id string) (Station, *Response, error)
 	List(lat float64, lng float64, rad int) ([]Station, *Response, error)
 }
 
@@ -33,15 +34,56 @@ type Station struct {
 	E5          interface{} `json:"e5"`          // Price for E5 fuel type
 	E10         interface{} `json:"e10"`         // Price for E10 fuel type
 	Street      string      `json:"street"`      // Street
+
+	// Following Properties are only avaliable, when Detail() was called
+
+	Overrides    []string      `json:"overrides"`
+	WholeDay     bool          `json:"wholeDay"`
+	State        string        `json:"state"`
+	OpeningTimes []openingTime `json:"openingTimes"`
+}
+
+// openingTime represents an openin time of the station
+type openingTime struct {
+	Text  string `json:"text"`
+	Start string `json:"start"`
+	End   string `json:"end"`
 }
 
 // stationRoot represents a response from the Tankerkönig-API.
 type stationsRoot struct {
-	Status   string    `json:"status"`
-	Ok       bool      `json:"ok"`
-	License  string    `json:"license"`
-	Data     string    `json:"data"`
+	Status  string `json:"status"`
+	Ok      bool   `json:"ok"`
+	License string `json:"license"`
+	Data    string `json:"data"`
+
+	// Stations is avaliable when List() was called
 	Stations []Station `json:"stations"`
+
+	// Station is avaliable when Detail() was called
+	Station Station `json:"station"`
+}
+
+// Detail returns the station for the given ID
+func (s *StationServiceOp) Detail(id string) (Station, *Response, error) {
+	path := "json/detail.php"
+
+	query := url.Values{}
+	query.Add("id", id)
+	query.Add("apikey", s.client.APIKey)
+
+	req, err := s.client.NewRequest("GET", path, query, nil)
+	if err != nil {
+		return Station{}, nil, err
+	}
+
+	root := new(stationsRoot)
+	resp, err := s.client.Do(req, root)
+	if err != nil {
+		return Station{}, nil, err
+	}
+
+	return root.Station, resp, nil
 }
 
 // List returns all stations within a radius of a location.


### PR DESCRIPTION
This adds the ability to call `client.Station.Detail(ID)` to get the opening times of a gas station.